### PR TITLE
State pattern for FTPClient

### DIFF
--- a/src/main/java/FTPClient.java
+++ b/src/main/java/FTPClient.java
@@ -1,21 +1,20 @@
-import java.util.Scanner;
+import states.InputState;
 
-import parsing.Command;
-import parsing.Parser;
-
-public class FTPClient {
-	public static void main(String[] args) {
-		Scanner sc = new Scanner(System.in);
-		Command command = null;
-		String input;
-		
-		System.out.println("Type 'help' for a list of commands");
-		
-		for (;;) {
-			input = sc.nextLine();
-			command = Parser.parse(input.split(" "));
-			command.execute();
-		}
+public class FTPClient extends Thread {
+	private states.State state;
+	
+	public FTPClient() {
+		this.state = new InputState();
 	}
-
+	
+	@Override
+	public void run() {	
+		while(true)
+			state = state.execute();
+	}
+	
+	public static void main(String[] args) {
+		FTPClient client = new FTPClient();
+		client.start();
+	}
 }

--- a/src/main/java/parsing/Command.java
+++ b/src/main/java/parsing/Command.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import logging.Logger;
+import states.State;
 
 
 public abstract class Command {
@@ -26,7 +27,7 @@ public abstract class Command {
 		setLogLevel();
 	}
 	
-	public abstract void execute();
+	public abstract State execute();
 	
 	public String getOperation() {
 		return operation;

--- a/src/main/java/parsing/ExitCommand.java
+++ b/src/main/java/parsing/ExitCommand.java
@@ -2,6 +2,9 @@ package parsing;
 
 import java.util.List;
 
+import states.ExitState;
+import states.State;
+
 public class ExitCommand extends Command {
 	private static final String EXIT_OPERATION = "exit";
 	private static final String EXIT_FORMAT = "";
@@ -15,8 +18,8 @@ public class ExitCommand extends Command {
 	}
 	
 	@Override
-	public void execute() {
+	public State execute() {
 		LOG.logQuiet("Shutting down.");
-		System.exit(0);
+		return new ExitState();
 	}
 }

--- a/src/main/java/parsing/HelpCommand.java
+++ b/src/main/java/parsing/HelpCommand.java
@@ -2,6 +2,9 @@ package parsing;
 
 import java.util.List;
 
+import states.InputState;
+import states.State;
+
 public class HelpCommand extends Command {
 	private static final String HELP_OPERATION = "help";
 	private static final String HELP_FORMAT = "";
@@ -15,7 +18,7 @@ public class HelpCommand extends Command {
 	}
 	
 	@Override
-	public void execute() {
+	public State execute() {
 		Command cmd;
 		
 		cmd = new ReadCommand(tokens);
@@ -29,5 +32,6 @@ public class HelpCommand extends Command {
 
 		cmd = new ExitCommand(tokens);
 		System.out.println(">> " + cmd.toHelp());
+		return new InputState();
 	}
 }

--- a/src/main/java/parsing/Parser.java
+++ b/src/main/java/parsing/Parser.java
@@ -1,4 +1,7 @@
 package parsing;
+
+import parsing.Command;
+
 public class Parser {
 	public static Command parse(String[] tokens) {
 		Command cmd;

--- a/src/main/java/parsing/ReadCommand.java
+++ b/src/main/java/parsing/ReadCommand.java
@@ -1,25 +1,16 @@
 package parsing;
 
-import exceptions.InvalidPacketException;
-import formats.AckMessage;
-import formats.DataMessage;
-import formats.Message.MessageType;
-import formats.RequestMessage;
 import logging.Logger;
-import resources.ResourceManager;
-import socket.TFTPDatagramSocket;
+import states.InputState;
+import states.ReadState;
+import states.State;
 
-import java.io.IOException;
-import java.net.DatagramPacket;
 import java.net.UnknownHostException;
 import java.util.List;
-
-import static resources.Configuration.GLOBAL_CONFIG;
 
 public class ReadCommand extends SocketCommand {
 	private static final Logger LOG = new Logger("FTPClient - Read");
 	private static final String READ_OPERATION = "read";
-	private TFTPDatagramSocket socket;
 
 	public ReadCommand(List<String> tokens) {
 		super(READ_OPERATION, tokens);
@@ -30,71 +21,15 @@ public class ReadCommand extends SocketCommand {
 	}
 
 	@Override
-	public void execute() {
-		if(this.tokens.size() < 3) {
+	public State execute() {
+		if (this.tokens.size() < 3)
 			LOG.logQuiet("Error: Not enough arguments");
-		}
-		else {
-
-			int expBlockNum = -1;
+		else
 			try {
-				// Create the resource manager, handle IOException if failed to get resource directory
-				ResourceManager resourceManager = new ResourceManager(GLOBAL_CONFIG.CLIENT_RESOURCE_DIR);
-
-			    socket = new TFTPDatagramSocket();
-				socket.setSoTimeout(SOCKET_TIMEOUT);
-
-				// Set up + Send RRQ Message
-                RequestMessage rrqMessage = new RequestMessage(MessageType.RRQ ,this.getFilename());
-				socket.sendMessage(rrqMessage, this.getServerAddress());
-				LOG.logQuiet("---- Begin File Transaction ---");
-                LOG.logQuiet("Read request sent!");
-                LOG.logQuiet("Waiting to receive data");
-
-				for(;;) {
-
-					try {
-					    // Receive read data from server
-                        DatagramPacket recv = socket.receivePacket();
-                        DataMessage dataMessage = DataMessage.parseMessageFromPacket(recv);
-                        LOG.logVerbose("Received data block: " + dataMessage.getBlockNum());
-            
-                        // Initialize block number to one sent from server
-                        if(expBlockNum == -1)
-                            expBlockNum = dataMessage.getBlockNum();
-
-                        // Confirm expected block number
-                        if(dataMessage.getBlockNum() != expBlockNum)
-                            throw new Error("Unexpected Block Number");
-
-                        // Write to file
-                        resourceManager.writeBytesToFile(this.getFilename(), dataMessage.getData());
-
-                        // Send ACK and increment block num
-                        AckMessage ackMsg = new AckMessage(expBlockNum++);
-                        socket.sendMessage(ackMsg, recv.getSocketAddress());
-                        LOG.logVerbose("Sent Ack for block: " + ackMsg.getBlockNum());
-
-                        // Check if this was the last block
-                        if(dataMessage.isFinalBlock()) {
-                            LOG.logVerbose("End of read file reached");
-							LOG.logQuiet("Successfully received file");
-							LOG.logQuiet("---- End File Transaction ---");
-                            break;
-                        }
-
-                    } catch (InvalidPacketException e) {
-                        e.printStackTrace();
-                    }
-				}
-			} catch(UnknownHostException uHE) {
-				LOG.logQuiet("Error: Unknown Host Entered");
-			} catch(IOException ioE) {
-				LOG.logVerbose("An IOException has occurred: " + ioE.getLocalizedMessage());
-				ioE.printStackTrace();
-			} finally {
-				socket.close();
+				return new ReadState(getServerAddress(), getFilename(), isVerbose());
+			} catch (UnknownHostException e) {
+				e.printStackTrace();
 			}
-		}
+		return new InputState();
 	}
 }

--- a/src/main/java/parsing/SocketCommand.java
+++ b/src/main/java/parsing/SocketCommand.java
@@ -1,7 +1,5 @@
 package parsing;
 
-import logging.Logger;
-
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -80,14 +78,6 @@ public abstract class SocketCommand extends Command {
 				return true;
 		}
 		return false;
-	}
-	
-	@Override
-	protected void setLogLevel() {
-		if (isVerbose())
-			Logger.setLogLevel(Logger.LogLevel.VERBOSE);
-		else
-			Logger.setLogLevel(Logger.LogLevel.QUIET);
 	}
 	
 	private InetSocketAddress errorSimulatorAddress() throws UnknownHostException {

--- a/src/main/java/parsing/SocketCommand.java
+++ b/src/main/java/parsing/SocketCommand.java
@@ -1,5 +1,7 @@
 package parsing;
 
+import parsing.Command;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;

--- a/src/main/java/parsing/WriteCommand.java
+++ b/src/main/java/parsing/WriteCommand.java
@@ -1,28 +1,16 @@
 package parsing;
 
-import exceptions.InvalidPacketException;
-import formats.AckMessage;
-import formats.DataMessage;
-import formats.Message.MessageType;
-import formats.RequestMessage;
 import logging.Logger;
-import resources.ResourceManager;
-import socket.TFTPDatagramSocket;
+import states.InputState;
+import states.State;
+import states.WriteState;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.SocketAddress;
-import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.List;
-
-import static resources.Configuration.GLOBAL_CONFIG;
 
 public class WriteCommand extends SocketCommand {
     private static final Logger LOG = new Logger("FTPClient - Write");
 	private static final String WRITE_OPERATION = "write";
-	private TFTPDatagramSocket socket;
 
 	public WriteCommand(List<String> tokens) {
 		super(WRITE_OPERATION, tokens);
@@ -31,91 +19,17 @@ public class WriteCommand extends SocketCommand {
 	public WriteCommand(String[] tokens) {
 		super(WRITE_OPERATION, tokens);
 	}
-
+	
 	@Override
-	public void execute() {
-        if(this.tokens.size() < 3) {
-            LOG.logQuiet("Error: Not enough arguments");
-        }
-        else {
-            try {
-                ResourceManager resourceManager = new ResourceManager(GLOBAL_CONFIG.CLIENT_RESOURCE_DIR);
-                if(!resourceManager.fileExists(this.getFilename()))
-                    throw new FileNotFoundException("File Not Found");
-
-                socket = new TFTPDatagramSocket();
-                socket.setSoTimeout(SOCKET_TIMEOUT);
-
-                try {
-
-                    // Create the write request & send
-                    RequestMessage wrqMessage = new RequestMessage(MessageType.WRQ ,this.getFilename());
-                    socket.sendMessage(wrqMessage, this.getServerAddress());
-                    LOG.logQuiet("---- Begin File Transaction ---");
-                    LOG.logQuiet("Write Request has been sent!");
-
-
-                    // Wait for WRQ ack
-                    DatagramPacket recv = socket.receivePacket();
-                    AckMessage ack = AckMessage.parseMessageFromPacket(recv);
-                    LOG.logVerbose("Received WRQ ACK");
-
-                    if(ack.getBlockNum() != 0) throw new IOException("Incorrect Initial Block Number");
-
-                    sendDataBlock(resourceManager.readFileToBytes(this.getFilename()), recv.getSocketAddress());
-                    LOG.logQuiet("Successfully completed write operation");
-                    LOG.logQuiet("---- End File Transaction ---");
-                } catch(InvalidPacketException ipE) {
-                    LOG.logQuiet(ipE.getMessage());
-                } catch(UnknownHostException uHE) {
-                    LOG.logQuiet("Error: Unknown Host Entered");
-                } catch(IOException ioE) {
-                    ioE.printStackTrace();
-                }
-                socket.close();
-            } catch (SocketException sE) {
-                    sE.printStackTrace();
-            } catch (FileNotFoundException fNFE) {
-                LOG.logQuiet("Error: " + fNFE.getMessage());
-            } catch (IOException ioE) {
-                LOG.logVerbose("IOException occurred. " + ioE.getLocalizedMessage());
-            }
-        }
+	public State execute() {
+		if (this.tokens.size() < 3)
+			LOG.logQuiet("Error: Not enough arguments");
+		else
+			try {
+				return new WriteState(getServerAddress(), getFilename(), isVerbose());
+			} catch (UnknownHostException e) {
+				e.printStackTrace();
+			}
+		return new InputState();
 	}
-
-	/**
-	 * Sends an array of bytes over TFTP, splicing the data in blocks if necessary
-     * @param data The array of data
-     * @param socketAddress The Socket address used in sending packet
-     * @throws IOException
-    */
-    private void sendDataBlock(byte[] data, SocketAddress socketAddress) throws IOException {
-
-        // Create a sequence of data for the byte array
-        List<DataMessage> messages = DataMessage.createDataMessageSequence(data);
-        LOG.logVerbose("Sending " + messages.size() + " Data messages to " + socketAddress);
-
-        try {
-            // Send each data block sequentially
-            for(DataMessage m : messages) {
-
-                LOG.logVerbose("Block: " + m.getBlockNum() + ", Data size: " + m.getDataSize() + ", Final Block: " + m.isFinalBlock());
-
-                // Send Data block message
-                socket.sendMessage(m, socketAddress);
-
-                // Wait for Ack message before continuing
-                DatagramPacket packet = socket.receivePacket();
-                AckMessage ack = AckMessage.parseMessageFromPacket(packet);
-                LOG.logVerbose("Ack Received: " + ack.getBlockNum());
-
-                if(ack.getBlockNum() != m.getBlockNum()) {
-                    throw new InvalidPacketException("Invalid Block Number");
-                }
-            }
-        } catch (InvalidPacketException e) {
-            e.printStackTrace();
-            throw new IOException("Failed to parse Ack Message", e);
-        }
-    }
 }

--- a/src/main/java/resources/Configuration.java
+++ b/src/main/java/resources/Configuration.java
@@ -8,7 +8,7 @@ import logging.Logger;
 import java.io.IOException;
 
 public class Configuration {
-    private static final Logger LOG = new Logger("Configuration");
+    private static final Logger LOG = new logging.Logger("Configuration");
     private static final String CONFIG_NAME = "config.json";
     private static final String CONFIG_DIR = "config";
     public static final Configuration GLOBAL_CONFIG = loadConfiguration(CONFIG_NAME);

--- a/src/main/java/states/ExitState.java
+++ b/src/main/java/states/ExitState.java
@@ -1,0 +1,11 @@
+package states;
+
+public class ExitState extends State {
+
+	@Override
+	public State execute() {
+		System.exit(0);
+		return null;
+	}
+
+}

--- a/src/main/java/states/InputState.java
+++ b/src/main/java/states/InputState.java
@@ -12,8 +12,8 @@ public class InputState extends State {
 		
 		Scanner sc = new Scanner(System.in);
 		String input = sc.nextLine();
-		sc.close();
 		Command command = Parser.parse(input.split(" "));
+		
 		return command.execute();
 	}
 }

--- a/src/main/java/states/InputState.java
+++ b/src/main/java/states/InputState.java
@@ -1,0 +1,19 @@
+package states;
+
+import java.util.Scanner;
+
+import parsing.Command;
+import parsing.Parser;
+
+public class InputState extends State {
+	@Override
+	public State execute() {
+		System.out.println("Type 'help' for a list of commands");
+		
+		Scanner sc = new Scanner(System.in);
+		String input = sc.nextLine();
+		sc.close();
+		Command command = Parser.parse(input.split(" "));
+		return command.execute();
+	}
+}

--- a/src/main/java/states/ReadState.java
+++ b/src/main/java/states/ReadState.java
@@ -1,0 +1,99 @@
+package states;
+
+import static resources.Configuration.GLOBAL_CONFIG;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+
+import exceptions.InvalidPacketException;
+import formats.AckMessage;
+import formats.DataMessage;
+import formats.RequestMessage;
+import logging.Logger;
+import formats.Message.MessageType;
+import resources.ResourceManager;
+import socket.TFTPDatagramSocket;
+
+public class ReadState extends State {
+	private static final int SOCKET_TIMEOUT = 5000;
+	
+	private TFTPDatagramSocket socket;
+	private SocketAddress serverAddress;
+	private String filename;
+	
+	public ReadState(SocketAddress serverAddress, String filename, boolean isVerbose) {
+		this.serverAddress = serverAddress;
+		this.filename = filename;
+		if (isVerbose)
+			Logger.setLogLevel(Logger.LogLevel.VERBOSE);
+		else
+			Logger.setLogLevel(Logger.LogLevel.QUIET);
+	}
+
+	@Override
+	public State execute() {
+		int expBlockNum = -1;
+		try {
+			// Create the resource manager, handle IOException if failed to get resource directory
+			ResourceManager resourceManager = new ResourceManager(GLOBAL_CONFIG.CLIENT_RESOURCE_DIR);
+
+		    socket = new TFTPDatagramSocket();
+			socket.setSoTimeout(SOCKET_TIMEOUT);
+
+			// Set up + Send RRQ Message
+            RequestMessage rrqMessage = new RequestMessage(MessageType.RRQ ,filename);
+			socket.sendMessage(rrqMessage, serverAddress);
+			LOG.logQuiet("---- Begin File Transaction ---");
+            LOG.logQuiet("Read request sent!");
+            LOG.logQuiet("Waiting to receive data");
+
+			for(;;) {
+
+				try {
+				    // Receive read data from server
+                    DatagramPacket recv = socket.receivePacket();
+                    DataMessage dataMessage = DataMessage.parseMessageFromPacket(recv);
+                    LOG.logVerbose("Received data block: " + dataMessage.getBlockNum());
+        
+                    // Initialize block number to one sent from server
+                    if(expBlockNum == -1)
+                        expBlockNum = dataMessage.getBlockNum();
+
+                    // Confirm expected block number
+                    if(dataMessage.getBlockNum() != expBlockNum)
+                        throw new Error("Unexpected Block Number");
+
+                    // Write to file
+                    resourceManager.writeBytesToFile(filename, dataMessage.getData());
+
+                    // Send ACK and increment block number
+                    AckMessage ackMsg = new AckMessage(expBlockNum++);
+                    socket.sendMessage(ackMsg, recv.getSocketAddress());
+                    LOG.logVerbose("Sent Ack for block: " + ackMsg.getBlockNum());
+
+                    // Check if this was the last block
+                    if(dataMessage.isFinalBlock()) {
+                    		LOG.logVerbose("End of read file reached");
+						LOG.logQuiet("Successfully received file");
+						LOG.logQuiet("---- End File Transaction ---");
+						break;
+                    }
+
+                } catch (InvalidPacketException e) {
+                    e.printStackTrace();
+                }
+			}
+		} catch(UnknownHostException uHE) {
+			LOG.logQuiet("Error: Unknown Host Entered");
+		} catch(IOException ioE) {
+			LOG.logVerbose("An IOException has occurred: " + ioE.getLocalizedMessage());
+			ioE.printStackTrace();
+		} finally {
+			socket.close();
+		}
+		
+		return new InputState();
+	}
+}

--- a/src/main/java/states/State.java
+++ b/src/main/java/states/State.java
@@ -1,0 +1,10 @@
+package states;
+
+import logging.Logger;
+
+
+public abstract class State {
+	protected static final Logger LOG = new Logger("FTPClient");
+		
+	public abstract State execute();
+}

--- a/src/main/java/states/WriteState.java
+++ b/src/main/java/states/WriteState.java
@@ -1,0 +1,121 @@
+package states;
+
+import static resources.Configuration.GLOBAL_CONFIG;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import exceptions.InvalidPacketException;
+import formats.AckMessage;
+import formats.DataMessage;
+import formats.RequestMessage;
+import formats.Message.MessageType;
+import logging.Logger;
+import resources.ResourceManager;
+import socket.TFTPDatagramSocket;
+
+public class WriteState extends State {
+	private static final int SOCKET_TIMEOUT = 5000;
+	
+	private TFTPDatagramSocket socket;
+	private SocketAddress serverAddress;
+	private String filename;
+	
+	public WriteState(SocketAddress serverAddress, String filename, boolean isVerbose) {
+		this.serverAddress = serverAddress;
+		this.filename = filename;
+		if (isVerbose)
+			Logger.setLogLevel(Logger.LogLevel.VERBOSE);
+		else
+			Logger.setLogLevel(Logger.LogLevel.QUIET);
+	}
+
+	@Override
+	public State execute() {
+        try {
+            ResourceManager resourceManager = new ResourceManager(GLOBAL_CONFIG.CLIENT_RESOURCE_DIR);
+            if(!resourceManager.fileExists(filename))
+                throw new FileNotFoundException("File Not Found");
+
+            socket = new TFTPDatagramSocket();
+            socket.setSoTimeout(SOCKET_TIMEOUT);
+
+            try {
+
+                // Create the write request & send
+                RequestMessage wrqMessage = new RequestMessage(MessageType.WRQ, filename);
+                socket.sendMessage(wrqMessage, serverAddress);
+                LOG.logQuiet("---- Begin File Transaction ---");
+                LOG.logQuiet("Write Request has been sent!");
+
+
+                // Wait for WRQ ack
+                DatagramPacket recv = socket.receivePacket();
+                AckMessage ack = AckMessage.parseMessageFromPacket(recv);
+                LOG.logVerbose("Received WRQ ACK");
+
+                if(ack.getBlockNum() != 0) throw new IOException("Incorrect Initial Block Number");
+
+                sendDataBlock(resourceManager.readFileToBytes(filename), recv.getSocketAddress());
+                LOG.logQuiet("Successfully completed write operation");
+                LOG.logQuiet("---- End File Transaction ---");
+            } catch(InvalidPacketException ipE) {
+                LOG.logQuiet(ipE.getMessage());
+            } catch(UnknownHostException uHE) {
+                LOG.logQuiet("Error: Unknown Host Entered");
+            } catch(IOException ioE) {
+                ioE.printStackTrace();
+            }
+            socket.close();
+        } catch (SocketException sE) {
+                sE.printStackTrace();
+        } catch (FileNotFoundException fNFE) {
+            LOG.logQuiet("Error: " + fNFE.getMessage());
+        } catch (IOException ioE) {
+            LOG.logVerbose("IOException occurred. " + ioE.getLocalizedMessage());
+        }
+        return new InputState();
+	}
+
+	/**
+	 * Sends an array of bytes over TFTP, splicing the data in blocks if necessary
+     * @param data The array of data
+     * @param socketAddress The Socket address used in sending packet
+     * @throws IOException
+    */
+    private void sendDataBlock(byte[] data, SocketAddress socketAddress) throws IOException {
+
+        // Create a sequence of data for the byte array
+        List<DataMessage> messages = DataMessage.createDataMessageSequence(data);
+        LOG.logVerbose("Sending " + messages.size() + " Data messages to " + socketAddress);
+
+        try {
+            // Send each data block sequentially
+            for(DataMessage m : messages) {
+
+                LOG.logVerbose("Block: " + m.getBlockNum() + ", Data size: " + m.getDataSize() + ", Final Block: " + m.isFinalBlock());
+
+                // Send Data block message
+                socket.sendMessage(m, socketAddress);
+
+                // Wait for Ack message before continuing
+                DatagramPacket packet = socket.receivePacket();
+                AckMessage ack = AckMessage.parseMessageFromPacket(packet);
+                LOG.logVerbose("Ack Received: " + ack.getBlockNum());
+
+                if(ack.getBlockNum() != m.getBlockNum()) {
+                    throw new InvalidPacketException("Invalid Block Number");
+                }
+            }
+        } catch (InvalidPacketException e) {
+            e.printStackTrace();
+            throw new IOException("Failed to parse Ack Message", e);
+        }
+    }
+
+}

--- a/src/test/java/parsing/CommandTest.java
+++ b/src/test/java/parsing/CommandTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import parsing.Command;
+import parsing.Parser;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
I had to use `mvn exec:java -Dexec.mainClass="FTPClient" -e` from the command line to run the project.

I've refactored the client code into a state pattern. I'm going to try to do the same thing with the Error Simulator if the code for this passes review.