### PR TITLE
Error simulator - error modes

### DIFF
--- a/src/main/java/ErrorSimulator.java
+++ b/src/main/java/ErrorSimulator.java
@@ -169,7 +169,7 @@ public class ErrorSimulator extends Thread {
 						LOG.logQuiet("Set Log Level to: " + Logger.getLogLevel().name());
 						break;
 					case "help":
-						System.out.println("Commands:\n'exit' -> Shutdown the simulator\n'l' -> Toggle verbose / quiet logging");
+						System.out.println(toHelp());
 						break;
 					default:
 						state = Parser.parseStateInformation(
@@ -190,5 +190,25 @@ public class ErrorSimulator extends Thread {
 		{
 			// Ignore this. Result of empty line buffer in scanner when exiting
 		}
+	}
+	
+	public static String toHelp() {
+		StringBuffer buffer = new StringBuffer();
+		buffer.append("\n==== Commands: ====\n");
+		buffer.append("exit -> Shutdown the simulator\n");
+		buffer.append("l -> Toggle verbose / quiet logging\n");
+		buffer.append("\n==== Error Mode States ====\n");
+		buffer.append("normal\n");
+		buffer.append("dup TYPE [BLOCK_NUM] [REPEAT_INTERVAL]\n");
+		buffer.append("lose TYPE [BLOCK_NUM] [REPEAT_INTERVAL]\n");
+		buffer.append("delay TYPE [BLOCK_NUM] [REPEAT_INTERVAL] DELAY_IN_MILLISECONDS\n");
+		buffer.append("\n==== Packet Types for Error Mode States ====\n");
+		buffer.append("ack, data, rrq, wrq\n");
+		buffer.append("\n==== Example Commands for Error Mode States ====\n");
+		buffer.append("dup ack 4 2 - Duplicate every second packet beginning with number 4.\n");
+		buffer.append("lose data 1 - Lose the first data packet.\n");
+		buffer.append("delay rrq 6000 - Delay RRQ by 6 seconds.\n");
+		buffer.append("delay ack 1 4 6000 - Delay every 4th Ack by 6 seconds.\n");
+		return buffer.toString();
 	}
 }

--- a/src/main/java/ErrorSimulator.java
+++ b/src/main/java/ErrorSimulator.java
@@ -18,11 +18,15 @@ public class ErrorSimulator extends Thread {
 	private static final Logger LOG = new Logger("ErrorSimulator");
 
 	public ErrorSimulator(InetAddress serverAddress) throws SocketException {
-		this.connection = new TFTPDatagramSocket(GLOBAL_CONFIG.SIMULATOR_PORT);
-		setState(new ForwardState(connection, serverAddress));
-
+		this(new TFTPDatagramSocket(GLOBAL_CONFIG.SIMULATOR_PORT));
+	}
+	
+	public ErrorSimulator(TFTPDatagramSocket socket) {
+		this.connection = socket;
+		setState(new ForwardState(connection, connection.getInetAddress()));
+		
 		LOG.logQuiet("Listening on port " + connection.getLocalPort());
-		LOG.logQuiet("Server Address: " + serverAddress);
+		LOG.logQuiet("Server Address: " + connection.getInetAddress());
 	}
 
 	public void stopServer() {

--- a/src/main/java/parsing/Parser.java
+++ b/src/main/java/parsing/Parser.java
@@ -70,7 +70,7 @@ public class Parser {
 			break;
 		}
 		return state;
-	}
+	}	
 	
 	private static ErrorChecker getChecker(String[] tokens) {
 		MessageType type;

--- a/src/main/java/parsing/Parser.java
+++ b/src/main/java/parsing/Parser.java
@@ -1,6 +1,18 @@
 package parsing;
 
+import static resources.Configuration.GLOBAL_CONFIG;
+
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.SocketException;
+
+import formats.Message.MessageType;
+import socket.TFTPDatagramSocket;
+import states.DelayPacketState;
+import states.DuplicateState;
+import states.ForwardState;
+import states.LostPacketState;
+import util.ErrorChecker;
 
 public class Parser {
 	public static Command parse(String[] tokens) throws IOException {
@@ -24,5 +36,78 @@ public class Parser {
 			break;
 		}
 		return cmd;
+	}
+	
+	public static ForwardState parseStateInformation(String[] tokens, TFTPDatagramSocket socket, InetAddress serverAddress) throws SocketException {
+		ForwardState state = null;
+
+		switch (tokens[0].toUpperCase()) {
+		case "DELAY":
+			state = new DelayPacketState(
+					socket,
+					serverAddress,
+					getChecker(subList(tokens, 1, tokens.length - 2)),
+					Long.parseLong(tokens[tokens.length - 1]));
+			break;
+		case "LOSE":
+			state = new LostPacketState(
+					socket,
+					serverAddress,
+					getChecker(subList(tokens, 1, tokens.length - 1)));
+			break;
+		case "DUP":
+			state = new DuplicateState(
+					socket,
+					serverAddress,
+					getChecker(subList(tokens, 1, tokens.length - 1)));
+			break;
+		case "NORMAL":
+			state = new ForwardState(socket, serverAddress);
+			break;
+		default:
+			System.out.println("'" + tokens[0] + "' is not a valid state.");
+			System.out.println("Type 'help' for a list of commands");
+			break;
+		}
+		return state;
+	}
+	
+	private static ErrorChecker getChecker(String[] tokens) {
+		MessageType type;
+		int blockNum = 0;
+		int replication = -1;
+		
+		if (tokens.length > 1) blockNum = Integer.parseInt(tokens[1]);
+		if (tokens.length > 2) replication = Integer.parseInt(tokens[2]);
+		
+		switch (tokens[0].toUpperCase()) {
+		case "ACK":
+			type = MessageType.ACK;
+			break;
+		case "DATA":
+			type = MessageType.DATA;
+			break;
+		case "RRQ":
+			return new ErrorChecker(MessageType.RRQ);
+		case "WRQ":
+			return new ErrorChecker(MessageType.WRQ);
+		default:
+			throw new ParseException("Invalid MessageType '" + tokens[0] + "'");
+		}
+		
+		return new ErrorChecker(type, blockNum, replication);
+	}
+	
+	private static String[] subList(String[] tokens, int startIndex, int endIndex) {
+		String[] tmp = new String[1 + endIndex - startIndex];
+		for (int i = 0; i <= endIndex - startIndex; i++)
+			tmp[i] = tokens[i + startIndex];
+		return tmp;
+	}
+}
+
+class ParseException extends RuntimeException {
+	public ParseException(String msg) {
+		super(msg);
 	}
 }

--- a/src/main/java/states/DelayPacketState.java
+++ b/src/main/java/states/DelayPacketState.java
@@ -1,0 +1,45 @@
+package states;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+
+import socket.TFTPDatagramSocket;
+import util.ErrorChecker;
+
+public class DelayPacketState extends ForwardState {
+	public static final int DEFAULT_DELAY = 1000;
+	
+	private ErrorChecker checker;
+	private long delayInMilliseconds;
+	
+	public DelayPacketState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker, long delayInMilliseconds) {
+		super(socket, serverAddress);
+		this.checker = checker;
+		this.delayInMilliseconds = delayInMilliseconds;
+	}
+	
+	public DelayPacketState(TFTPDatagramSocket socket, InetAddress serverAddress) {
+		this(socket, serverAddress, null, DEFAULT_DELAY);
+	}
+	
+	public void setErrorChecker(ErrorChecker checker) {
+		this.checker = checker;
+	}
+	
+	public void setDelay(long delay) {
+		this.delayInMilliseconds = delay;
+	}
+
+	@Override
+	protected void forwardPacket(DatagramPacket packet) throws IOException {
+		if (checker.check(packet)) {
+			try {
+				Thread.sleep(delayInMilliseconds);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+		super.forwardPacket(packet);
+	}
+}

--- a/src/main/java/states/DelayPacketState.java
+++ b/src/main/java/states/DelayPacketState.java
@@ -35,11 +35,14 @@ public class DelayPacketState extends ForwardState {
 	@Override
 	protected void forwardPacket(DatagramPacket packet) throws IOException {
 		if (checker.check(packet)) {
+			LOG.logQuiet("Delaying packet by " + delayInMilliseconds + " ms.");
+			LOG.logVerbose(packet);
 			try {
 				Thread.sleep(delayInMilliseconds);
 			} catch (InterruptedException e) {
 				e.printStackTrace();
 			}
+			LOG.logQuiet("Continuing to forward packet.");
 		}
 		super.forwardPacket(packet);
 	}

--- a/src/main/java/states/DelayPacketState.java
+++ b/src/main/java/states/DelayPacketState.java
@@ -3,6 +3,7 @@ package states;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.net.SocketException;
 
 import socket.TFTPDatagramSocket;
 import util.ErrorChecker;
@@ -13,13 +14,13 @@ public class DelayPacketState extends ForwardState {
 	private ErrorChecker checker;
 	private long delayInMilliseconds;
 	
-	public DelayPacketState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker, long delayInMilliseconds) {
+	public DelayPacketState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker, long delayInMilliseconds) throws SocketException {
 		super(socket, serverAddress);
 		this.checker = checker;
 		this.delayInMilliseconds = delayInMilliseconds;
 	}
 	
-	public DelayPacketState(TFTPDatagramSocket socket, InetAddress serverAddress) {
+	public DelayPacketState(TFTPDatagramSocket socket, InetAddress serverAddress) throws SocketException {
 		this(socket, serverAddress, null, DEFAULT_DELAY);
 	}
 	

--- a/src/main/java/states/DuplicateState.java
+++ b/src/main/java/states/DuplicateState.java
@@ -31,6 +31,8 @@ public class DuplicateState extends ForwardState {
 	protected void forwardPacket(DatagramPacket packet) throws IOException {
 		super.forwardPacket(packet);
 		if(checker.check(packet)) {
+			LOG.logQuiet("Duplicating packet.");
+			LOG.logVerbose(packet);
 			MessageType type = null;
 			try {
 				type = Message.getMessageType(packet.getData());
@@ -43,5 +45,4 @@ public class DuplicateState extends ForwardState {
 				super.forwardPacket(packet);
 		}
 	}
-
 }

--- a/src/main/java/states/DuplicateState.java
+++ b/src/main/java/states/DuplicateState.java
@@ -1,0 +1,46 @@
+package states;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+
+import exceptions.InvalidPacketException;
+import formats.Message;
+import formats.Message.MessageType;
+import socket.TFTPDatagramSocket;
+import util.ErrorChecker;
+
+public class DuplicateState extends ForwardState {
+	private ErrorChecker checker;
+	
+	public DuplicateState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker) {
+		super(socket, serverAddress);
+		this.checker = checker;
+	}
+	
+	public DuplicateState(TFTPDatagramSocket socket, InetAddress serverAddress) {
+		this(socket, serverAddress, null);
+	}
+	
+	public void setErrorChecker(ErrorChecker checker) {
+		this.checker = checker;
+	}
+	
+	@Override
+	protected void forwardPacket(DatagramPacket packet) throws IOException {
+		super.forwardPacket(packet);
+		if(checker.check(packet)) {
+			MessageType type = null;
+			try {
+				type = Message.getMessageType(packet.getData());
+			} catch (InvalidPacketException e) {
+				e.printStackTrace();
+			}
+			if(type == MessageType.RRQ || type == MessageType.WRQ) 
+				super.forwardRequest(packet, serverAddress);
+			else
+				super.forwardPacket(packet);
+		}
+	}
+
+}

--- a/src/main/java/states/DuplicateState.java
+++ b/src/main/java/states/DuplicateState.java
@@ -3,6 +3,7 @@ package states;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.net.SocketException;
 
 import exceptions.InvalidPacketException;
 import formats.Message;
@@ -13,12 +14,12 @@ import util.ErrorChecker;
 public class DuplicateState extends ForwardState {
 	private ErrorChecker checker;
 	
-	public DuplicateState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker) {
+	public DuplicateState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker) throws SocketException {
 		super(socket, serverAddress);
 		this.checker = checker;
 	}
 	
-	public DuplicateState(TFTPDatagramSocket socket, InetAddress serverAddress) {
+	public DuplicateState(TFTPDatagramSocket socket, InetAddress serverAddress) throws SocketException {
 		this(socket, serverAddress, null);
 	}
 	

--- a/src/main/java/states/ForwardState.java
+++ b/src/main/java/states/ForwardState.java
@@ -34,9 +34,9 @@ public class ForwardState extends State {
 		DatagramPacket incomingPacket;
 
 		LOG.logQuiet("Error Simulator is running.");
+		LOG.logVerbose("Waiting for request from client");
 		while (!connection.isClosed() && !stopping) {
 			try {
-				LOG.logVerbose("Waiting for request from client");
 				incomingPacket = connection.receive();
 				forwardPacket(incomingPacket);				
 			} catch (SocketException sE)

--- a/src/main/java/states/ForwardState.java
+++ b/src/main/java/states/ForwardState.java
@@ -86,8 +86,8 @@ public class ForwardState extends State {
 			LOG.logVerbose("Received server response. Worker thread port: " + currentServerWorkerPort);
 
 			// Now forward the initial response back to client
-			connection.forwardPacket(serverResponsePacket, clientAddress);
 			LOG.logQuiet("Forwarding initial response to client");
+			forwardPacket(serverResponsePacket);
 		}
 		// If the packet is from the server worker
 		// We are going to forward the packet to the current client

--- a/src/main/java/states/ForwardState.java
+++ b/src/main/java/states/ForwardState.java
@@ -98,6 +98,14 @@ public class ForwardState extends State {
 
 	}
 	
+	public void setServerWorkerPort(int port) {
+		this.currentServerWorkerPort = port;
+	}
+	
+	public void setClientAddress(InetSocketAddress clientAddress) {
+		this.clientAddress = clientAddress;
+	}
+	
 	/**
 	 * Checks to see if a request is coming from the current client.
 	 * @param addr The address to check

--- a/src/main/java/states/ForwardState.java
+++ b/src/main/java/states/ForwardState.java
@@ -32,7 +32,7 @@ public class ForwardState extends State {
 		while (!connection.isClosed()) {
 			try {
 				LOG.logVerbose("Waiting for request from client");
-				incomingPacket = connection.receivePacket();
+				incomingPacket = connection.receive();
 				forwardPacket(incomingPacket);				
 			} catch (SocketException sE)
 			{
@@ -70,7 +70,7 @@ public class ForwardState extends State {
 			forwardRequest(incomingPacket, serverAddress);
 
 			LOG.logVerbose("Waiting for initial response from server");
-			DatagramPacket serverResponsePacket = connection.receivePacket();
+			DatagramPacket serverResponsePacket = connection.receive();
 
 			// Now we learn the server workers PORT
 			currentServerWorkerPort = serverResponsePacket.getPort();

--- a/src/main/java/states/ForwardState.java
+++ b/src/main/java/states/ForwardState.java
@@ -16,9 +16,9 @@ public class ForwardState extends State {
 	protected static final Logger LOG = new Logger("ErrorSimulator");
 
 	private TFTPDatagramSocket connection;
-	private InetAddress serverAddress;
+	protected InetAddress serverAddress;
 	private InetSocketAddress clientAddress;
-	private int currentServerWorkerPort;
+	protected int currentServerWorkerPort;
 	
 	public ForwardState(TFTPDatagramSocket connection, InetAddress serverAddress) {
 		this.connection = connection;
@@ -33,47 +33,8 @@ public class ForwardState extends State {
 		while (!connection.isClosed()) {
 			try {
 				LOG.logVerbose("Waiting for request from client");
-				incomingPacket = receivePacket();
-				InetAddress incomingAddr = incomingPacket.getAddress();
-				int incomingPort = incomingPacket.getPort();
-
-				// Check to see what the source IP is
-				// If the request is not from the current client AND not from the server worker,
-				// We have a new client (and will forward this ONE packet to server port 69)
-				if(!isFromClient(incomingAddr, incomingPort) && !isFromServerWorker(incomingAddr, incomingPort))
-				{
-					LOG.logQuiet("New Client Detected.");
-					clientAddress = new InetSocketAddress(incomingPacket.getAddress(), incomingPacket.getPort());
-
-					LOG.logQuiet("Forwarding initial request to server");
-					connection.forwardPacket(incomingPacket, serverAddress, GLOBAL_CONFIG.SERVER_PORT);
-
-					LOG.logVerbose("Waiting for initial response from server");
-					DatagramPacket serverResponsePacket = receivePacket();
-
-					// Now we learn the server workers PORT
-					currentServerWorkerPort = serverResponsePacket.getPort();
-					LOG.logVerbose("Received server response. Worker thread port: " + currentServerWorkerPort);
-
-					// Now forward the initial response back to client
-					connection.forwardPacket(serverResponsePacket, clientAddress);
-					LOG.logQuiet("Forwarding initial response to client");
-				}
-				// If the packet is from the server worker
-				// We are going to forward the packet to the current client
-				else if(!isFromClient(incomingAddr, incomingPort) && isFromServerWorker(incomingAddr, incomingPort))
-				{
-					LOG.logQuiet("Received message from client. Forwarding to server.");
-					connection.forwardPacket(incomingPacket, clientAddress);
-				}
-				// If the packet is from the current client
-				// We are going to forward the packet to the server
-				else if(!isFromServerWorker(incomingAddr, incomingPort) && isFromClient(incomingAddr, incomingPort))
-				{
-					LOG.logQuiet("Received message from server. Forwarding to client.");
-					connection.forwardPacket(incomingPacket, serverAddress, currentServerWorkerPort);
-				}
-
+				incomingPacket = connection.receivePacket();
+				forwardPacket(incomingPacket);				
 			} catch (SocketException sE)
 			{
 				// Socket closed exception
@@ -83,16 +44,58 @@ public class ForwardState extends State {
 			catch (IOException e) {
 				e.printStackTrace();
 			}
+			catch (Exception e) {
+				if (e.getMessage().equals("TEST EXCEPTION"))
+					break;
+			}
 		}
 		return this;
 	}
 	
-	private DatagramPacket receivePacket() throws IOException {
-		DatagramPacket clientPacket = new DatagramPacket(new byte[Message.MAX_PACKET_SIZE], Message.MAX_PACKET_SIZE);
-		connection.receive(clientPacket);
-		LOG.logVerbose("Received Message Packet from " + clientPacket.getSocketAddress());
-		LOG.logVerbose(clientPacket);
-		return clientPacket;
+	protected void forwardRequest(DatagramPacket incomingPacket, InetAddress serverAddress) throws IOException {
+		connection.forwardPacket(incomingPacket, serverAddress, GLOBAL_CONFIG.SERVER_PORT);
+	}
+	protected void forwardPacket(DatagramPacket incomingPacket) throws IOException {
+		InetAddress incomingAddr = incomingPacket.getAddress();
+		int incomingPort = incomingPacket.getPort();
+		
+		// Check to see what the source IP is
+		// If the request is not from the current client AND not from the server worker,
+		// We have a new client (and will forward this ONE packet to server port 69)
+		if(!isFromClient(incomingAddr, incomingPort) && !isFromServerWorker(incomingAddr, incomingPort))
+		{
+			LOG.logQuiet("New Client Detected.");
+			clientAddress = new InetSocketAddress(incomingPacket.getAddress(), incomingPacket.getPort());
+
+			LOG.logQuiet("Forwarding initial request to server");
+			forwardRequest(incomingPacket, serverAddress);
+
+			LOG.logVerbose("Waiting for initial response from server");
+			DatagramPacket serverResponsePacket = connection.receivePacket();
+
+			// Now we learn the server workers PORT
+			currentServerWorkerPort = serverResponsePacket.getPort();
+			LOG.logVerbose("Received server response. Worker thread port: " + currentServerWorkerPort);
+
+			// Now forward the initial response back to client
+			connection.forwardPacket(serverResponsePacket, clientAddress);
+			LOG.logQuiet("Forwarding initial response to client");
+		}
+		// If the packet is from the server worker
+		// We are going to forward the packet to the current client
+		else if(!isFromClient(incomingAddr, incomingPort) && isFromServerWorker(incomingAddr, incomingPort))
+		{
+			LOG.logQuiet("Received message from client. Forwarding to server.");
+			connection.forwardPacket(incomingPacket, clientAddress);
+		}
+		// If the packet is from the current client
+		// We are going to forward the packet to the server
+		else if(!isFromServerWorker(incomingAddr, incomingPort) && isFromClient(incomingAddr, incomingPort))
+		{
+			LOG.logQuiet("Received message from server. Forwarding to client.");
+			connection.forwardPacket(incomingPacket, serverAddress, currentServerWorkerPort);
+		}
+
 	}
 	
 	/**

--- a/src/main/java/states/ForwardState.java
+++ b/src/main/java/states/ForwardState.java
@@ -8,7 +8,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 
-import formats.Message;
 import logging.Logger;
 import socket.TFTPDatagramSocket;
 

--- a/src/main/java/states/LostPacketState.java
+++ b/src/main/java/states/LostPacketState.java
@@ -27,7 +27,10 @@ public class LostPacketState extends ForwardState {
 
 	@Override
 	protected void forwardPacket(DatagramPacket packet) throws IOException {
-		if (checker.check(packet)) return;
+		if (checker.check(packet)) {
+			LOG.logQuiet("Dropping packet.");
+			LOG.logVerbose(packet);
+		}
 		super.forwardPacket(packet);
 	}
 }

--- a/src/main/java/states/LostPacketState.java
+++ b/src/main/java/states/LostPacketState.java
@@ -1,0 +1,35 @@
+package states;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+
+import exceptions.InvalidPacketException;
+import formats.Message;
+import formats.Message.MessageType;
+import socket.TFTPDatagramSocket;
+import util.ErrorChecker;
+
+public class LostPacketState extends ForwardState {
+	
+	private ErrorChecker checker;
+	
+	public LostPacketState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker) {
+		super(socket, serverAddress);
+		this.checker = checker;
+	}
+	
+	public LostPacketState(TFTPDatagramSocket socket, InetAddress serverAddress) {
+		this(socket, serverAddress, null);
+	}
+	
+	public void setErrorChecker(ErrorChecker checker) {
+		this.checker = checker;
+	}
+
+	@Override
+	protected void forwardPacket(DatagramPacket packet) throws IOException {
+		if (checker.check(packet)) return;
+		super.forwardPacket(packet);
+	}
+}

--- a/src/main/java/states/LostPacketState.java
+++ b/src/main/java/states/LostPacketState.java
@@ -4,9 +4,6 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 
-import exceptions.InvalidPacketException;
-import formats.Message;
-import formats.Message.MessageType;
 import socket.TFTPDatagramSocket;
 import util.ErrorChecker;
 

--- a/src/main/java/states/LostPacketState.java
+++ b/src/main/java/states/LostPacketState.java
@@ -3,6 +3,7 @@ package states;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.net.SocketException;
 
 import socket.TFTPDatagramSocket;
 import util.ErrorChecker;
@@ -11,12 +12,12 @@ public class LostPacketState extends ForwardState {
 	
 	private ErrorChecker checker;
 	
-	public LostPacketState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker) {
+	public LostPacketState(TFTPDatagramSocket socket, InetAddress serverAddress, ErrorChecker checker) throws SocketException {
 		super(socket, serverAddress);
 		this.checker = checker;
 	}
 	
-	public LostPacketState(TFTPDatagramSocket socket, InetAddress serverAddress) {
+	public LostPacketState(TFTPDatagramSocket socket, InetAddress serverAddress) throws SocketException {
 		this(socket, serverAddress, null);
 	}
 	

--- a/src/main/java/states/LostPacketState.java
+++ b/src/main/java/states/LostPacketState.java
@@ -30,6 +30,7 @@ public class LostPacketState extends ForwardState {
 		if (checker.check(packet)) {
 			LOG.logQuiet("Dropping packet.");
 			LOG.logVerbose(packet);
+			return;
 		}
 		super.forwardPacket(packet);
 	}

--- a/src/main/java/states/State.java
+++ b/src/main/java/states/State.java
@@ -7,4 +7,5 @@ public abstract class State {
 	protected static final Logger LOG = new Logger("FTPClient");
 		
 	public abstract State execute();
+	public void stopState() {}
 }

--- a/src/main/java/util/ErrorChecker.java
+++ b/src/main/java/util/ErrorChecker.java
@@ -1,0 +1,57 @@
+package util;
+
+import java.net.DatagramPacket;
+
+import exceptions.InvalidPacketException;
+import formats.AckMessage;
+import formats.DataMessage;
+import formats.Message;
+import formats.Message.MessageType;
+
+public class ErrorChecker {
+	private MessageType type;
+	private int blockNum;
+	private int replicator;
+	public ErrorChecker(MessageType type, int blockNum, int replicator) {
+		this.type = type;
+		this.blockNum = blockNum;
+		this.replicator = replicator;
+	}
+	
+	public ErrorChecker(MessageType type, int blockNum) {
+		this(type, blockNum, -1);
+	}
+	
+	public ErrorChecker(MessageType type) {
+		this(type, -1, -1);
+	}
+	
+	public boolean check(DatagramPacket packet) {
+		try {
+			if(Message.getMessageType(packet.getData()) != type) return false;
+			
+			int packetBlock = -1;
+			
+			switch(type) {
+			case RRQ:
+			case WRQ:
+			case ERROR:
+				return true;
+			case ACK:
+				packetBlock = AckMessage.parseMessageFromBytes(packet.getData()).getBlockNum();
+				break;
+			case DATA:
+				packetBlock = DataMessage.parseMessageFromBytes(packet.getData()).getBlockNum();
+				break;
+			}
+			
+			if (blockNum == packetBlock) {
+				blockNum += replicator;
+				return true;
+			}	
+		} catch (InvalidPacketException e) {
+			e.printStackTrace();
+		}
+		return false;
+	}	
+}

--- a/src/main/java/util/ErrorChecker.java
+++ b/src/main/java/util/ErrorChecker.java
@@ -38,10 +38,10 @@ public class ErrorChecker {
 			case ERROR:
 				return true;
 			case ACK:
-				packetBlock = AckMessage.parseMessageFromBytes(packet.getData()).getBlockNum();
+				packetBlock = AckMessage.parseMessage(packet.getData()).getBlockNum();
 				break;
 			case DATA:
-				packetBlock = DataMessage.parseMessageFromBytes(packet.getData()).getBlockNum();
+				packetBlock = DataMessage.parseMessage(packet.getData()).getBlockNum();
 				break;
 			}
 			

--- a/src/test/java/states/DelayPacketStateTest.java
+++ b/src/test/java/states/DelayPacketStateTest.java
@@ -6,6 +6,7 @@ import java.io.PrintStream;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 import org.junit.After;
@@ -40,7 +41,11 @@ public class DelayPacketStateTest {
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
-		state = new DelayPacketState(socket, serverAddress);
+		try {
+			state = new DelayPacketState(socket, serverAddress);
+		} catch (SocketException e) {
+			e.printStackTrace();
+		}
 		thread = new DelayStateThread(state);
 	}
 	@After

--- a/src/test/java/states/DelayPacketStateTest.java
+++ b/src/test/java/states/DelayPacketStateTest.java
@@ -1,0 +1,160 @@
+package states;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import formats.RequestMessage;
+import formats.AckMessage;
+import formats.DataMessage;
+import formats.Message.MessageType;
+import socket.TFTPDatagramSocket;
+import util.ErrorChecker;
+
+public class DelayPacketStateTest {
+	private DelayPacketState state;
+	private DelayStateThread thread;
+	private TFTPDatagramSocket socket;
+	private ErrorChecker checker;
+	private InetAddress serverAddress;
+	private InetSocketAddress connectionManagerSocketAddress;
+	
+	@Before
+	public void setup() {
+		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(outStream));
+		socket = Mockito.mock(TFTPDatagramSocket.class);
+		try {
+			serverAddress = InetAddress.getByName(StateTestConfig.SERVER_HOST);
+			connectionManagerSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
+		} catch (UnknownHostException e) {
+			e.printStackTrace();
+		}
+		state = new DelayPacketState(socket, serverAddress);
+		thread = new DelayStateThread(state);
+	}
+	@After
+	public void tearDown() {
+		System.setOut(System.out);
+	}
+	@Test
+	public void testDelayedRRQ() {
+		try {
+			checker = new ErrorChecker(MessageType.RRQ);
+			state.setErrorChecker(checker);
+
+			byte[] expectedRRQBytes = new RequestMessage(MessageType.RRQ, StateTestConfig.FILENAME).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
+
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			thread.start();
+
+			Mockito.verify(socket, Mockito.after(0).never()).forwardPacket(expectedPacket, serverAddress, 69);
+			Mockito.verify(socket, Mockito.after(DelayPacketState.DEFAULT_DELAY * 2).times(1)).forwardPacket(expectedPacket, serverAddress, 69);
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+	
+	@Test
+	public void testDelayWRQ() {
+		try {
+			checker = new ErrorChecker(MessageType.WRQ);
+			state.setErrorChecker(checker);
+			byte[] expectedWRQBytes = new RequestMessage(MessageType.WRQ, StateTestConfig.FILENAME).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
+
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			thread.start();
+			
+			Mockito.verify(socket, Mockito.after(0).never()).forwardPacket(expectedPacket, serverAddress, 69);
+			Mockito.verify(socket, Mockito.after(DelayPacketState.DEFAULT_DELAY * 2).times(1)).forwardPacket(expectedPacket, serverAddress, 69);	
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+	
+	@Test
+	public void testLostData() {
+		try {
+			checker = new ErrorChecker(MessageType.DATA, 1);
+			state.setErrorChecker(checker);
+			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
+
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			state.setServerWorkerPort(3000);
+			state.setClientAddress(connectionManagerSocketAddress);
+			
+			thread.start();
+			
+			Mockito.verify(socket, Mockito.after(0).never())
+				.forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
+			Mockito.verify(socket, Mockito.after(DelayPacketState.DEFAULT_DELAY * 2).times(1))
+				.forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+
+	@Test
+	public void testLostACK() {
+		try {
+			checker = new ErrorChecker(MessageType.ACK, 1);
+			state.setErrorChecker(checker);
+
+			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+
+			state.setServerWorkerPort(3000);
+			state.setClientAddress(connectionManagerSocketAddress);
+			
+			thread.start();
+			
+			Mockito.verify(socket, Mockito.after(0).never())
+				.forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
+			Mockito.verify(socket, Mockito.after(DelayPacketState.DEFAULT_DELAY * 2).times(1))
+				.forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+}
+
+class DelayStateThread extends Thread {
+	private DelayPacketState state;
+	public DelayStateThread(DelayPacketState state) {
+		this.state = state;
+	}
+	
+	@Override
+	public void run() {
+		state.execute();
+	}
+}

--- a/src/test/java/states/DelayPacketStateTest.java
+++ b/src/test/java/states/DelayPacketStateTest.java
@@ -57,7 +57,7 @@ public class DelayPacketStateTest {
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
 
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
@@ -79,7 +79,7 @@ public class DelayPacketStateTest {
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
 
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
@@ -101,7 +101,7 @@ public class DelayPacketStateTest {
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
 
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
@@ -128,7 +128,7 @@ public class DelayPacketStateTest {
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 

--- a/src/test/java/states/DelayPacketStateTest.java
+++ b/src/test/java/states/DelayPacketStateTest.java
@@ -28,7 +28,7 @@ public class DelayPacketStateTest {
 	private TFTPDatagramSocket socket;
 	private ErrorChecker checker;
 	private InetAddress serverAddress;
-	private InetSocketAddress connectionManagerSocketAddress;
+	private InetSocketAddress serverSocketAddress;
 	
 	@Before
 	public void setup() {
@@ -37,7 +37,7 @@ public class DelayPacketStateTest {
 		socket = Mockito.mock(TFTPDatagramSocket.class);
 		try {
 			serverAddress = InetAddress.getByName(StateTestConfig.SERVER_HOST);
-			connectionManagerSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
+			serverSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
@@ -60,7 +60,7 @@ public class DelayPacketStateTest {
 
 			byte[] expectedRRQBytes = new RequestMessage(MessageType.RRQ, StateTestConfig.FILENAME).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, serverSocketAddress);
 
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
@@ -82,7 +82,7 @@ public class DelayPacketStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedWRQBytes = new RequestMessage(MessageType.WRQ, StateTestConfig.FILENAME).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, serverSocketAddress);
 
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
@@ -104,14 +104,14 @@ public class DelayPacketStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, serverSocketAddress);
 
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
 			state.setServerWorkerPort(3000);
-			state.setClientAddress(connectionManagerSocketAddress);
+			state.setClientAddress(serverSocketAddress);
 			
 			thread.start();
 			
@@ -132,13 +132,13 @@ public class DelayPacketStateTest {
 
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, serverSocketAddress);
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 
 			state.setServerWorkerPort(3000);
-			state.setClientAddress(connectionManagerSocketAddress);
+			state.setClientAddress(serverSocketAddress);
 			
 			thread.start();
 			

--- a/src/test/java/states/DuplicateStateTest.java
+++ b/src/test/java/states/DuplicateStateTest.java
@@ -56,7 +56,7 @@ public class DuplicateStateTest {
 			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
 			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
 			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
@@ -78,7 +78,7 @@ public class DuplicateStateTest {
 			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
 			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
 			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
@@ -100,7 +100,7 @@ public class DuplicateStateTest {
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
 			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
 			DatagramPacket serverResponse = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
@@ -123,7 +123,7 @@ public class DuplicateStateTest {
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
 			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
 			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));

--- a/src/test/java/states/DuplicateStateTest.java
+++ b/src/test/java/states/DuplicateStateTest.java
@@ -6,6 +6,7 @@ import java.io.PrintStream;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 import org.junit.After;
@@ -41,7 +42,11 @@ public class DuplicateStateTest {
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
-		state = new DuplicateState(socket, serverAddress);
+		try {
+			state = new DuplicateState(socket, serverAddress);
+		} catch (SocketException e) {
+			e.printStackTrace();
+		}
 	}
 	@After
 	public void tearDown() {

--- a/src/test/java/states/DuplicateStateTest.java
+++ b/src/test/java/states/DuplicateStateTest.java
@@ -29,7 +29,7 @@ public class DuplicateStateTest {
 	private TFTPDatagramSocket socket;
 	private ErrorChecker checker;
 	private InetAddress serverAddress;
-	private InetSocketAddress connectionManagerSocketAddress;
+	private InetSocketAddress serverSocketAddress;
 	
 	@Before
 	public void setup() {
@@ -38,7 +38,7 @@ public class DuplicateStateTest {
 		socket = Mockito.mock(TFTPDatagramSocket.class);
 		try {
 			serverAddress = InetAddress.getByName(StateTestConfig.SERVER_HOST);
-			connectionManagerSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
+			serverSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
@@ -59,8 +59,8 @@ public class DuplicateStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedRRQBytes = new RequestMessage(MessageType.RRQ, StateTestConfig.FILENAME).toByteArray();
 			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
-			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
-			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, serverSocketAddress);
+			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, serverSocketAddress);
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
@@ -81,8 +81,8 @@ public class DuplicateStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedWRQBytes = new RequestMessage(MessageType.WRQ, StateTestConfig.FILENAME).toByteArray();
 			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
-			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
-			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, serverSocketAddress);
+			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, serverSocketAddress);
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
@@ -103,14 +103,14 @@ public class DuplicateStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
-			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
-			DatagramPacket serverResponse = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, serverSocketAddress);
+			DatagramPacket serverResponse = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, serverSocketAddress);
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			state.setServerWorkerPort(3000);
-			state.setClientAddress(connectionManagerSocketAddress);
+			state.setClientAddress(serverSocketAddress);
 			state.execute();
 			Mockito.verify(socket, Mockito.times(2)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
 					
@@ -126,14 +126,14 @@ public class DuplicateStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedDataBytes = new DataMessage(2, new byte[] { 0 }).toByteArray();
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
-			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
-			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
+			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, serverSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, serverSocketAddress);
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			state.setServerWorkerPort(3000);
-			state.setClientAddress(connectionManagerSocketAddress);
+			state.setClientAddress(serverSocketAddress);
 			state.execute();
 			Mockito.verify(socket, Mockito.times(2)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
 					

--- a/src/test/java/states/DuplicateStateTest.java
+++ b/src/test/java/states/DuplicateStateTest.java
@@ -107,9 +107,10 @@ public class DuplicateStateTest {
 				.thenReturn(expectedPacket)
 				.thenReturn(serverResponse)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
-			
+			state.setServerWorkerPort(3000);
+			state.setClientAddress(connectionManagerSocketAddress);
 			state.execute();
-			Mockito.verify(socket, Mockito.times(2)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.any(Integer.class));
+			Mockito.verify(socket, Mockito.times(2)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
 					
 		} catch (IOException e) {
             Assert.fail(e.getMessage());
@@ -118,9 +119,25 @@ public class DuplicateStateTest {
 	
 	@Test
 	public void testDuplicateACK() {
-		checker = new ErrorChecker(MessageType.ACK);
-		state.setErrorChecker(checker);
-		fail();
+		try {
+			checker = new ErrorChecker(MessageType.ACK, 1);
+			state.setErrorChecker(checker);
+			byte[] expectedDataBytes = new DataMessage(2, new byte[] { 0 }).toByteArray();
+			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
+			DatagramPacket serverResponse = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenReturn(serverResponse)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			state.setServerWorkerPort(3000);
+			state.setClientAddress(connectionManagerSocketAddress);
+			state.execute();
+			Mockito.verify(socket, Mockito.times(2)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
+					
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
 	}
 
 }

--- a/src/test/java/states/DuplicateStateTest.java
+++ b/src/test/java/states/DuplicateStateTest.java
@@ -1,7 +1,5 @@
 package states;
 
-import static org.junit.Assert.*;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -18,7 +16,6 @@ import org.mockito.Mockito;
 
 import formats.AckMessage;
 import formats.DataMessage;
-import formats.Message;
 import formats.RequestMessage;
 import formats.Message.MessageType;
 import socket.TFTPDatagramSocket;

--- a/src/test/java/states/DuplicateStateTest.java
+++ b/src/test/java/states/DuplicateStateTest.java
@@ -1,0 +1,111 @@
+package states;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import formats.AckMessage;
+import formats.DataMessage;
+import formats.Message;
+import formats.RequestMessage;
+import formats.Message.MessageType;
+import socket.TFTPDatagramSocket;
+import util.ErrorChecker;
+
+public class DuplicateStateTest {
+//  lose a packet; 2 : delay a packet, 3 : duplicate a
+	// packet.
+	private DuplicateState state;
+	private TFTPDatagramSocket socket;
+	private ErrorChecker checker;
+	private InetAddress serverAddress;
+	private InetSocketAddress connectionManagerSocketAddress;
+	
+	@Before
+	public void setup() {
+		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(outStream));
+		socket = Mockito.mock(TFTPDatagramSocket.class);
+		try {
+			serverAddress = InetAddress.getByName(StateTestConfig.SERVER_HOST);
+			connectionManagerSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
+		} catch (UnknownHostException e) {
+			e.printStackTrace();
+		}
+		state = new DuplicateState(socket, serverAddress);
+	}
+	@After
+	public void tearDown() {
+		System.setOut(System.out);
+	}
+	@Test
+	public void testDuplicateRRQ() {
+		try {
+			checker = new ErrorChecker(MessageType.RRQ);
+			state.setErrorChecker(checker);
+			byte[] expectedRRQBytes = new RequestMessage(MessageType.RRQ, StateTestConfig.FILENAME).toByteArray();
+			byte[] expectedWRQBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
+			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
+			DatagramPacket serverResponse = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenReturn(serverResponse)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			state.execute();
+			Mockito.verify(socket, Mockito.times(2)).forwardPacket(expectedPacket, serverAddress, 69);
+					
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+	
+	@Test
+	public void testDuplicateWRQ() {
+		try {
+			checker = new ErrorChecker(MessageType.WRQ);
+			state.setErrorChecker(checker);
+			byte[] expectedRRQBytes = new RequestMessage(MessageType.WRQ, StateTestConfig.FILENAME).toByteArray();
+			byte[] expectedWRQBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
+			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
+			DatagramPacket serverResponse = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenReturn(serverResponse)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			state.execute();
+			Mockito.verify(socket, Mockito.times(2)).forwardPacket(expectedPacket, serverAddress, 69);
+					
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+	
+	@Test
+	public void testDuplicateData() {
+		checker = new ErrorChecker(MessageType.DATA);
+		state.setErrorChecker(checker);
+		fail();
+	}
+	
+	@Test
+	public void testDuplicateACK() {
+		checker = new ErrorChecker(MessageType.ACK);
+		state.setErrorChecker(checker);
+		fail();
+	}
+
+}

--- a/src/test/java/states/LostPacketStateTest.java
+++ b/src/test/java/states/LostPacketStateTest.java
@@ -6,6 +6,7 @@ import java.io.PrintStream;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 import org.junit.After;
@@ -39,7 +40,11 @@ public class LostPacketStateTest {
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
-		state = new LostPacketState(socket, serverAddress);
+		try {
+			state = new LostPacketState(socket, serverAddress);
+		} catch (SocketException e) {
+			e.printStackTrace();
+		}
 	}
 	@After
 	public void tearDown() {

--- a/src/test/java/states/LostPacketStateTest.java
+++ b/src/test/java/states/LostPacketStateTest.java
@@ -27,7 +27,7 @@ public class LostPacketStateTest {
 	private TFTPDatagramSocket socket;
 	private ErrorChecker checker;
 	private InetAddress serverAddress;
-	private InetSocketAddress connectionManagerSocketAddress;
+	private InetSocketAddress serverSocketAddress;
 	
 	@Before
 	public void setup() {
@@ -36,7 +36,7 @@ public class LostPacketStateTest {
 		socket = Mockito.mock(TFTPDatagramSocket.class);
 		try {
 			serverAddress = InetAddress.getByName(StateTestConfig.SERVER_HOST);
-			connectionManagerSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
+			serverSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
@@ -57,7 +57,7 @@ public class LostPacketStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedRRQBytes = new RequestMessage(MessageType.RRQ, StateTestConfig.FILENAME).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, serverSocketAddress);
 
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
@@ -78,7 +78,7 @@ public class LostPacketStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedWRQBytes = new RequestMessage(MessageType.WRQ, StateTestConfig.FILENAME).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, serverSocketAddress);
 
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
@@ -99,14 +99,14 @@ public class LostPacketStateTest {
 			state.setErrorChecker(checker);
 			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, serverSocketAddress);
 
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
 			state.setServerWorkerPort(3000);
-			state.setClientAddress(connectionManagerSocketAddress);
+			state.setClientAddress(serverSocketAddress);
 			state.execute();
 			
 			Mockito.verify(socket, Mockito.times(0)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
@@ -123,13 +123,13 @@ public class LostPacketStateTest {
 
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
 
-			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
+			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, serverSocketAddress);
 			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 
 			state.setServerWorkerPort(3000);
-			state.setClientAddress(connectionManagerSocketAddress);
+			state.setClientAddress(serverSocketAddress);
 			state.execute();
 
 			Mockito.verify(socket, Mockito.times(0)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));		

--- a/src/test/java/states/LostPacketStateTest.java
+++ b/src/test/java/states/LostPacketStateTest.java
@@ -54,7 +54,7 @@ public class LostPacketStateTest {
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
 
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
@@ -75,7 +75,7 @@ public class LostPacketStateTest {
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
 
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
@@ -96,7 +96,7 @@ public class LostPacketStateTest {
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
 
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 			
@@ -119,7 +119,7 @@ public class LostPacketStateTest {
 			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
 
 			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
-			Mockito.when(socket.receivePacket())
+			Mockito.when(socket.receive())
 				.thenReturn(expectedPacket)
 				.thenThrow(new RuntimeException("TEST EXCEPTION"));
 

--- a/src/test/java/states/LostPacketStateTest.java
+++ b/src/test/java/states/LostPacketStateTest.java
@@ -1,7 +1,5 @@
 package states;
 
-import static org.junit.Assert.*;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -18,7 +16,6 @@ import org.mockito.Mockito;
 
 import formats.AckMessage;
 import formats.DataMessage;
-import formats.Message;
 import formats.RequestMessage;
 import formats.Message.MessageType;
 import socket.TFTPDatagramSocket;

--- a/src/test/java/states/LostPacketStateTest.java
+++ b/src/test/java/states/LostPacketStateTest.java
@@ -1,0 +1,139 @@
+package states;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import formats.AckMessage;
+import formats.DataMessage;
+import formats.Message;
+import formats.RequestMessage;
+import formats.Message.MessageType;
+import socket.TFTPDatagramSocket;
+import util.ErrorChecker;
+
+public class LostPacketStateTest {
+	private LostPacketState state;
+	private TFTPDatagramSocket socket;
+	private ErrorChecker checker;
+	private InetAddress serverAddress;
+	private InetSocketAddress connectionManagerSocketAddress;
+	
+	@Before
+	public void setup() {
+		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(outStream));
+		socket = Mockito.mock(TFTPDatagramSocket.class);
+		try {
+			serverAddress = InetAddress.getByName(StateTestConfig.SERVER_HOST);
+			connectionManagerSocketAddress = new InetSocketAddress(InetAddress.getByName(StateTestConfig.SERVER_HOST), 1069);
+		} catch (UnknownHostException e) {
+			e.printStackTrace();
+		}
+		state = new LostPacketState(socket, serverAddress);
+	}
+	@After
+	public void tearDown() {
+		System.setOut(System.out);
+	}
+	@Test
+	public void testLostRRQ() {
+		try {
+			checker = new ErrorChecker(MessageType.RRQ);
+			state.setErrorChecker(checker);
+			byte[] expectedRRQBytes = new RequestMessage(MessageType.RRQ, StateTestConfig.FILENAME).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedRRQBytes, expectedRRQBytes.length, connectionManagerSocketAddress);
+
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			state.execute();
+			
+			Mockito.verify(socket, Mockito.times(0)).forwardPacket(expectedPacket, serverAddress, 69);		
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+	
+	@Test
+	public void testLostWRQ() {
+		try {
+			checker = new ErrorChecker(MessageType.WRQ);
+			state.setErrorChecker(checker);
+			byte[] expectedWRQBytes = new RequestMessage(MessageType.WRQ, StateTestConfig.FILENAME).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedWRQBytes, expectedWRQBytes.length, connectionManagerSocketAddress);
+
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			state.execute();
+			Mockito.verify(socket, Mockito.times(0)).forwardPacket(expectedPacket, serverAddress, 69);
+					
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+	
+	@Test
+	public void testLostData() {
+		try {
+			checker = new ErrorChecker(MessageType.DATA, 1);
+			state.setErrorChecker(checker);
+			byte[] expectedDataBytes = new DataMessage(1, new byte[] { 0 }).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedDataBytes, expectedDataBytes.length, connectionManagerSocketAddress);
+
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+			
+			state.setServerWorkerPort(3000);
+			state.setClientAddress(connectionManagerSocketAddress);
+			state.execute();
+			
+			Mockito.verify(socket, Mockito.times(0)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+	
+	@Test
+	public void testLostACK() {
+		try {
+			checker = new ErrorChecker(MessageType.ACK, 1);
+			state.setErrorChecker(checker);
+
+			byte[] expectedACKBytes = new AckMessage(1).toByteArray();
+
+			DatagramPacket expectedPacket = new DatagramPacket(expectedACKBytes, expectedACKBytes.length, connectionManagerSocketAddress);
+			Mockito.when(socket.receivePacket())
+				.thenReturn(expectedPacket)
+				.thenThrow(new RuntimeException("TEST EXCEPTION"));
+
+			state.setServerWorkerPort(3000);
+			state.setClientAddress(connectionManagerSocketAddress);
+			state.execute();
+
+			Mockito.verify(socket, Mockito.times(0)).forwardPacket(Mockito.eq(expectedPacket), Mockito.eq(serverAddress), Mockito.eq(3000));		
+		} catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+	}
+
+}

--- a/src/test/java/util/ErrorCheckerTest.java
+++ b/src/test/java/util/ErrorCheckerTest.java
@@ -1,0 +1,122 @@
+package util;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import exceptions.InvalidPacketException;
+import formats.AckMessage;
+import formats.DataMessage;
+import formats.ErrorMessage;
+import formats.ErrorMessage.ErrorType;
+import formats.Message.MessageType;
+import formats.RequestMessage;
+
+public class ErrorCheckerTest {
+	private DatagramPacket ack1, ack2, rrq, wrq, data1, data2, error;
+
+	
+	@Before
+	public void setup() {
+		try
+		{
+			byte [] ack1Byte = new AckMessage(1).toByteArray();
+			byte [] ack2Byte = new AckMessage(2).toByteArray();
+			byte [] rrqByte = new RequestMessage(MessageType.RRQ, "Beer.txt").toByteArray();
+			byte [] wrqByte = new RequestMessage(MessageType.WRQ, "Wine.txt").toByteArray();
+			byte [] data1Byte = new DataMessage(1, new byte[] { 1 }).toByteArray();
+			byte [] data2Byte = new DataMessage(2, new byte[] { 1 }).toByteArray();
+			byte [] errorByte = new ErrorMessage(ErrorType.ACCESS_VIOLATION, "Don't touch my whiskey").toByteArray();
+			ack1 = new DatagramPacket(ack1Byte, ack1Byte.length);
+			ack2 = new DatagramPacket(ack2Byte, ack2Byte.length);
+			rrq = new DatagramPacket(rrqByte, rrqByte.length);
+			wrq = new DatagramPacket(wrqByte, wrqByte.length);
+			data1 = new DatagramPacket(data1Byte, data1Byte.length);
+			data2 = new DatagramPacket(data2Byte, data2Byte.length);
+			error = new DatagramPacket(errorByte, errorByte.length);
+		}  catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	@Test
+	public void testCheckAck() {
+		ErrorChecker checker = new ErrorChecker(MessageType.ACK, 1);
+		assertTrue(checker.check(ack1));
+		assertFalse(checker.check(ack2));
+		assertFalse(checker.check(data1));
+		assertFalse(checker.check(data2));
+		assertFalse(checker.check(error));
+		assertFalse(checker.check(rrq));
+		assertFalse(checker.check(wrq));
+	}
+	
+	@Test
+	public void testCheckManyAck() {
+		ErrorChecker checker = new ErrorChecker(MessageType.ACK, 1, 3);
+		byte[] ack4Byte = null;
+		try {
+			ack4Byte = new AckMessage(4).toByteArray();
+		} catch (IOException e) {
+			fail();
+		}
+		DatagramPacket ack4 = new DatagramPacket(ack4Byte, ack4Byte.length);
+		assertTrue(checker.check(ack1));
+		assertFalse(checker.check(ack2));
+		assertTrue(checker.check(ack4));
+	}
+	
+	@Test
+	public void testCheckData() {
+		ErrorChecker checker = new ErrorChecker(MessageType.DATA, 1);
+		assertFalse(checker.check(ack1));
+		assertFalse(checker.check(ack2));
+		assertTrue(checker.check(data1));
+		assertFalse(checker.check(data2));
+		assertFalse(checker.check(error));
+		assertFalse(checker.check(rrq));
+		assertFalse(checker.check(wrq));
+	}
+	
+	@Test
+	public void testCheckRRQ() {
+		ErrorChecker checker = new ErrorChecker(MessageType.RRQ);
+		assertFalse(checker.check(ack1));
+		assertFalse(checker.check(ack2));
+		assertFalse(checker.check(data1));
+		assertFalse(checker.check(data2));
+		assertFalse(checker.check(error));
+		assertTrue(checker.check(rrq));
+		assertFalse(checker.check(wrq));
+	}
+	
+	@Test
+	public void testCheckWRQ() {
+		ErrorChecker checker = new ErrorChecker(MessageType.WRQ);
+		assertFalse(checker.check(ack1));
+		assertFalse(checker.check(ack2));
+		assertFalse(checker.check(data1));
+		assertFalse(checker.check(data2));
+		assertFalse(checker.check(error));
+		assertFalse(checker.check(rrq));
+		assertTrue(checker.check(wrq));
+	}
+	
+	@Test
+	public void testCheckError() {
+		ErrorChecker checker = new ErrorChecker(MessageType.ERROR);
+		assertFalse(checker.check(ack1));
+		assertFalse(checker.check(ack2));
+		assertFalse(checker.check(data1));
+		assertFalse(checker.check(data2));
+		assertTrue(checker.check(error));
+		assertFalse(checker.check(rrq));
+		assertFalse(checker.check(wrq));
+	}
+	
+
+}


### PR DESCRIPTION
Here are the help messages I've added to the error simulator.

```
==== Commands: ====
exit -> Shutdown the simulator
l -> Toggle verbose / quiet logging

==== Error Mode States ====
normal
dup TYPE [BLOCK_NUM] [REPEAT_INTERVAL]
lose TYPE [BLOCK_NUM] [REPEAT_INTERVAL]
delay TYPE [BLOCK_NUM] [REPEAT_INTERVAL] DELAY_IN_MILLISECONDS

==== Packet Types for Error Mode States ====
ack, data, rrq, wrq

==== Example Commands for Error Mode States ====
dup ack 4 2 - Duplicate every second packet beginning with number 4.
lose data 1 - Lose the first data packet.
delay rrq 6000 - Delay RRQ by 6 seconds.
delay ack 1 4 6000 - Delay every 4th Ack by 6 seconds.
```